### PR TITLE
Changed hackspace to makerspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 documentation
 =============
 
-Documentation, legal forms, and other common media related to the Swindon Hackspace.
+Documentation, legal forms, and other common media related to the Swindon Makerspace.


### PR DESCRIPTION
I noticed the readme referenced `hackspace` so changed it to `makerspace`.